### PR TITLE
Fix the parsing error reading requirements.dev.txt during setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read(path):
 def clean(deps):
     res = []
     for dep in deps:
-        if dep and not dep.startswith('#') and not dep.startswith('git'):
+        if dep and not dep.startswith('#') and not dep.startswith('git') and not dep.startswith('-r'):
             res.append(dep)
     return res
 
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(exclude=['examples', 'tests']),
     package_dir={package['slug']: package['slug']},
     install_requires=requirements,
-    tests_require=requirements_dev,
+    tests_require=requirements_dev + requirements,
     test_suite='nose.collector',
     zip_safe=False,
     keywords=package['keywords'],


### PR DESCRIPTION
I ran into a parsing problem when I tried to install the package. The `tests_require` parameter didn't like the first line: `-r requirements.txt`.
